### PR TITLE
Updated pom.xml version to a generic snapshot version

### DIFF
--- a/config/archetype/pom.xml
+++ b/config/archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-config</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-archetype</artifactId>
   <packaging>pom</packaging>

--- a/config/archetype/quickstart/pom.xml
+++ b/config/archetype/quickstart/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-archetype</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-archetype-quickstart</artifactId>
   <packaging>maven-archetype</packaging>

--- a/config/checkstyle/pom.xml
+++ b/config/checkstyle/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-config</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-checkstyle</artifactId>
   <packaging>jar</packaging>

--- a/config/deploy/pom.xml
+++ b/config/deploy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-config</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-deploy</artifactId>
   <name>Rice Deploy</name>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-config</artifactId>
   <packaging>pom</packaging>

--- a/db/config/pom.xml
+++ b/db/config/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-db</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-db-config</artifactId>

--- a/db/impex/client/bootstrap/pom.xml
+++ b/db/impex/client/bootstrap/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-impex-client</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-impex-client-bootstrap</artifactId>

--- a/db/impex/client/demo/pom.xml
+++ b/db/impex/client/demo/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-impex-client</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-impex-client-demo</artifactId>

--- a/db/impex/client/pom.xml
+++ b/db/impex/client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-impex</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-impex-client</artifactId>

--- a/db/impex/master/pom.xml
+++ b/db/impex/master/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-impex</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-impex-master</artifactId>

--- a/db/impex/pom.xml
+++ b/db/impex/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-db</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-impex</artifactId>

--- a/db/impex/server/bootstrap/pom.xml
+++ b/db/impex/server/bootstrap/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-impex-server</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-impex-server-bootstrap</artifactId>

--- a/db/impex/server/demo/pom.xml
+++ b/db/impex/server/demo/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-impex-server</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-impex-server-demo</artifactId>

--- a/db/impex/server/pom.xml
+++ b/db/impex/server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-impex</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-impex-server</artifactId>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-db</artifactId>
   <packaging>pom</packaging>

--- a/db/sql/pom.xml
+++ b/db/sql/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-db</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-sql</artifactId>

--- a/db/xml/pom.xml
+++ b/db/xml/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-db</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-xml</artifactId>

--- a/development-tools/pom.xml
+++ b/development-tools/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-development-tools</artifactId>
   <properties>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-dist</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <packaging>pom</packaging>
   <name>Rice</name>
   <inceptionYear>2005</inceptionYear>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <description>
     The Kuali Rice effort provides an enterprise class middleware suite of integrated products that allows
     both Kuali and non-Kuali applications

--- a/rice-framework/krad-app-framework/pom.xml
+++ b/rice-framework/krad-app-framework/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>rice-framework</artifactId>
         <groupId>org.kuali.rice</groupId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-krad-app-framework</artifactId>
 

--- a/rice-framework/krad-data/pom.xml
+++ b/rice-framework/krad-data/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>rice-framework</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-framework/krad-development-tools/pom.xml
+++ b/rice-framework/krad-development-tools/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-framework</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-krad-development-tools</artifactId>

--- a/rice-framework/krad-it/pom.xml
+++ b/rice-framework/krad-it/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-framework</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-krad</artifactId>
 

--- a/rice-framework/krad-sampleapp/impl/pom.xml
+++ b/rice-framework/krad-sampleapp/impl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-krad-sampleapp</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-framework/krad-sampleapp/pom.xml
+++ b/rice-framework/krad-sampleapp/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-framework</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-framework/krad-sampleapp/web/pom.xml
+++ b/rice-framework/krad-sampleapp/web/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-krad-sampleapp</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-framework/krad-service-impl/pom.xml
+++ b/rice-framework/krad-service-impl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-framework</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-framework/krad-theme-builder/pom.xml
+++ b/rice-framework/krad-theme-builder/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>rice-framework</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-krad-theme-builder</artifactId>

--- a/rice-framework/krad-theme-builder/src/test/builder/pom.xml
+++ b/rice-framework/krad-theme-builder/src/test/builder/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>rice-framework</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
     <relativePath>../../../../pom.xml</relativePath>
   </parent>
 

--- a/rice-framework/krad-web-framework/pom.xml
+++ b/rice-framework/krad-web-framework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>rice-framework</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-krad-web-framework</artifactId>

--- a/rice-framework/krad-web/pom.xml
+++ b/rice-framework/krad-web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-framework</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-krad-web</artifactId>

--- a/rice-framework/pom.xml
+++ b/rice-framework/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-middleware/client-contrib/pom.xml
+++ b/rice-middleware/client-contrib/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-middleware</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-middleware/core-service/api/pom.xml
+++ b/rice-middleware/core-service/api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-core-service</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/rice-middleware/core-service/framework/pom.xml
+++ b/rice-middleware/core-service/framework/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>rice-core-service</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-middleware/core-service/impl/pom.xml
+++ b/rice-middleware/core-service/impl/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-core-service</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <profiles>

--- a/rice-middleware/core-service/pom.xml
+++ b/rice-middleware/core-service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kuali.rice</groupId>
         <artifactId>rice-middleware</artifactId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-core-service</artifactId>
     <packaging>pom</packaging>

--- a/rice-middleware/core-service/web/pom.xml
+++ b/rice-middleware/core-service/web/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>rice-core-service</artifactId>
         <groupId>org.kuali.rice</groupId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rice-middleware/core/api/pom.xml
+++ b/rice-middleware/core/api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-core</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-core-api</artifactId>
 

--- a/rice-middleware/core/framework/pom.xml
+++ b/rice-middleware/core/framework/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-core</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-middleware/core/impl/pom.xml
+++ b/rice-middleware/core/impl/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.kuali.rice</groupId>
         <artifactId>rice-core</artifactId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/rice-middleware/core/pom.xml
+++ b/rice-middleware/core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kuali.rice</groupId>
         <artifactId>rice-middleware</artifactId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-core</artifactId>
     <packaging>pom</packaging>

--- a/rice-middleware/core/web/pom.xml
+++ b/rice-middleware/core/web/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>rice-core</artifactId>
         <groupId>org.kuali.rice</groupId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rice-middleware/edl/framework/pom.xml
+++ b/rice-middleware/edl/framework/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>rice-edl</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-edl-framework</artifactId>
   <name>Rice EDL Framework</name>

--- a/rice-middleware/edl/impl/pom.xml
+++ b/rice-middleware/edl/impl/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>rice-edl</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-edl-impl</artifactId>
   <name>Rice EDL Impl</name>

--- a/rice-middleware/edl/pom.xml
+++ b/rice-middleware/edl/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <artifactId>rice-middleware</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-edl</artifactId>
   <packaging>pom</packaging>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <name>Rice EDL</name>
   <modules>
   	<module>framework</module>

--- a/rice-middleware/impl/pom.xml
+++ b/rice-middleware/impl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-middleware</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-impl</artifactId>
 

--- a/rice-middleware/it/config/pom.xml
+++ b/rice-middleware/it/config/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-it</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-config</artifactId>
   <name>Rice Integration Test Config</name>

--- a/rice-middleware/it/core/pom.xml
+++ b/rice-middleware/it/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-it</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-core</artifactId>
   <name>Rice Integration Test Core</name>

--- a/rice-middleware/it/edl/pom.xml
+++ b/rice-middleware/it/edl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-it</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-edl</artifactId>
 

--- a/rice-middleware/it/impl/pom.xml
+++ b/rice-middleware/it/impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-it</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-impl</artifactId>
 

--- a/rice-middleware/it/internal-tools/pom.xml
+++ b/rice-middleware/it/internal-tools/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-it</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-internal-tools</artifactId>
 

--- a/rice-middleware/it/kcb/pom.xml
+++ b/rice-middleware/it/kcb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-it</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-kcb</artifactId>
 

--- a/rice-middleware/it/ken/pom.xml
+++ b/rice-middleware/it/ken/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.kuali.rice</groupId>
         <artifactId>rice-it</artifactId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-it-ken</artifactId>
 

--- a/rice-middleware/it/kew/pom.xml
+++ b/rice-middleware/it/kew/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-it</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-kew</artifactId>
 

--- a/rice-middleware/it/kim/pom.xml
+++ b/rice-middleware/it/kim/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kuali.rice</groupId>
         <artifactId>rice-it</artifactId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-it-kim</artifactId>
 

--- a/rice-middleware/it/kns/pom.xml
+++ b/rice-middleware/it/kns/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>rice-it</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-middleware/it/krms/pom.xml
+++ b/rice-middleware/it/krms/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-it</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-krms</artifactId>
   <name>Rice Integration Test KRMS</name>

--- a/rice-middleware/it/ksb/pom.xml
+++ b/rice-middleware/it/ksb/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-it</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-ksb</artifactId>
 

--- a/rice-middleware/it/location/pom.xml
+++ b/rice-middleware/it/location/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>rice-it</artifactId>
         <groupId>org.kuali.rice</groupId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-it-location</artifactId>
     <name>Rice Integration Test Location</name>

--- a/rice-middleware/it/pom.xml
+++ b/rice-middleware/it/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-middleware</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it</artifactId>
   <packaging>pom</packaging>

--- a/rice-middleware/it/remote/pom.xml
+++ b/rice-middleware/it/remote/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-it</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-remote</artifactId>
   <name>Rice Integration Test Remote</name>

--- a/rice-middleware/it/rice-it-kew-s3/pom.xml
+++ b/rice-middleware/it/rice-it-kew-s3/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-it</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-kew-s3</artifactId>
   

--- a/rice-middleware/it/rice-it-krad-s3/pom.xml
+++ b/rice-middleware/it/rice-it-krad-s3/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-it</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-krad-s3</artifactId>
 

--- a/rice-middleware/it/vc/pom.xml
+++ b/rice-middleware/it/vc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-it</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-it-vc</artifactId>
   <name>Rice Integration Test Version Compatibility</name>

--- a/rice-middleware/ken/api/pom.xml
+++ b/rice-middleware/ken/api/pom.xml
@@ -20,10 +20,10 @@
   <parent>
     <artifactId>rice-ken</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-ken-api</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <name>Rice KEN API</name>
 
   <dependencies>

--- a/rice-middleware/ken/pom.xml
+++ b/rice-middleware/ken/pom.xml
@@ -20,10 +20,10 @@
   <parent>
     <artifactId>rice-middleware</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-ken</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Rice KEN</name>
   <modules>

--- a/rice-middleware/kew/api/pom.xml
+++ b/rice-middleware/kew/api/pom.xml
@@ -20,10 +20,10 @@
   <parent>
     <artifactId>rice-kew</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-kew-api</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <name>Rice KEW API</name>
 
   <dependencies>

--- a/rice-middleware/kew/framework/pom.xml
+++ b/rice-middleware/kew/framework/pom.xml
@@ -20,10 +20,10 @@
   <parent>
     <artifactId>rice-kew</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-kew-framework</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <name>Rice KEW Framework</name>
 
   <dependencies>

--- a/rice-middleware/kew/impl/pom.xml
+++ b/rice-middleware/kew/impl/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <artifactId>rice-kew</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <groupId>org.kuali.rice</groupId>
   <artifactId>rice-kew-impl</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <name>Rice KEW Impl</name>
 
   <dependencies>

--- a/rice-middleware/kew/pom.xml
+++ b/rice-middleware/kew/pom.xml
@@ -20,10 +20,10 @@
   <parent>
     <artifactId>rice-middleware</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-kew</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Rice KEW</name>
   <modules>

--- a/rice-middleware/kim/kim-api/pom.xml
+++ b/rice-middleware/kim/kim-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-kim</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-kim-api</artifactId>
   <name>Rice KIM API</name>

--- a/rice-middleware/kim/kim-framework/pom.xml
+++ b/rice-middleware/kim/kim-framework/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>rice-kim</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-middleware/kim/kim-impl/pom.xml
+++ b/rice-middleware/kim/kim-impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>rice-kim</artifactId>
         <groupId>org.kuali.rice</groupId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-kim-impl</artifactId>
     <name>Rice KIM Impl</name>

--- a/rice-middleware/kim/kim-ldap/pom.xml
+++ b/rice-middleware/kim/kim-ldap/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-kim</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-kim-ldap</artifactId>
 

--- a/rice-middleware/kim/pom.xml
+++ b/rice-middleware/kim/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>rice-middleware</artifactId>
         <groupId>org.kuali.rice</groupId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-kim</artifactId>
 

--- a/rice-middleware/kns/pom.xml
+++ b/rice-middleware/kns/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>rice-middleware</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-kns</artifactId>
 

--- a/rice-middleware/krms/api/pom.xml
+++ b/rice-middleware/krms/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-krms</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-krms-api</artifactId>
   <name>Rice KRMS API</name>

--- a/rice-middleware/krms/framework/pom.xml
+++ b/rice-middleware/krms/framework/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-krms</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-krms-framework</artifactId>
   <name>Rice KRMS Framework</name>

--- a/rice-middleware/krms/gen/pom.xml
+++ b/rice-middleware/krms/gen/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-krms</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <name>Rice KRMS Gen</name>
   <artifactId>rice-krms-gen</artifactId>

--- a/rice-middleware/krms/impl/pom.xml
+++ b/rice-middleware/krms/impl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-krms</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <name>Rice KRMS Impl</name>
   <artifactId>rice-krms-impl</artifactId>

--- a/rice-middleware/krms/pom.xml
+++ b/rice-middleware/krms/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-middleware</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <name>Rice KRMS</name>
   <artifactId>rice-krms</artifactId>

--- a/rice-middleware/ksb/api/pom.xml
+++ b/rice-middleware/ksb/api/pom.xml
@@ -20,10 +20,10 @@
   <parent>
     <artifactId>rice-ksb</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-ksb-api</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <name>Rice KSB API</name>
   <dependencies>
     <dependency>

--- a/rice-middleware/ksb/client-impl/pom.xml
+++ b/rice-middleware/ksb/client-impl/pom.xml
@@ -21,11 +21,11 @@
   <parent>
     <artifactId>rice-ksb</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rice-ksb-client-impl</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <name>Rice KSB Client Implementation</name>
 
   <profiles>

--- a/rice-middleware/ksb/pom.xml
+++ b/rice-middleware/ksb/pom.xml
@@ -20,10 +20,10 @@
   <parent>
     <artifactId>rice-middleware</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-ksb</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Rice KSB</name>
   <modules>

--- a/rice-middleware/ksb/server-impl/pom.xml
+++ b/rice-middleware/ksb/server-impl/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <artifactId>rice-ksb</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>rice-ksb-server-impl</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <name>Rice KSB Server Implementation</name>
 
   <profiles>

--- a/rice-middleware/ksb/web/pom.xml
+++ b/rice-middleware/ksb/web/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <artifactId>rice-ksb</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>rice-ksb-web</artifactId>
-  <version>2.6.0-M1-SNAPSHOT</version>
+  <version>2.6.x-SNAPSHOT</version>
   <name>Rice KSB Web Application</name>
 
   <dependencies>

--- a/rice-middleware/legacy-web/pom.xml
+++ b/rice-middleware/legacy-web/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>rice-middleware</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/rice-middleware/location/api/pom.xml
+++ b/rice-middleware/location/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-location</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-location-api</artifactId>
   <name>Rice Location API</name>

--- a/rice-middleware/location/framework/pom.xml
+++ b/rice-middleware/location/framework/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>rice-location</artifactId>
         <groupId>org.kuali.rice</groupId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-location-framework</artifactId>
     <name>Rice Location Framework</name>

--- a/rice-middleware/location/impl/pom.xml
+++ b/rice-middleware/location/impl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>rice-location</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-location-impl</artifactId>
   <name>Rice Location Impl</name>

--- a/rice-middleware/location/pom.xml
+++ b/rice-middleware/location/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>rice-middleware</artifactId>
         <groupId>org.kuali.rice</groupId>
-        <version>2.6.0-M1-SNAPSHOT</version>
+        <version>2.6.x-SNAPSHOT</version>
     </parent>
     <artifactId>rice-location</artifactId>
     <name>Rice Location</name>

--- a/rice-middleware/location/web/pom.xml
+++ b/rice-middleware/location/web/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>rice-location</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Rice Location Web</name>

--- a/rice-middleware/pom.xml
+++ b/rice-middleware/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>rice</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
 
   <artifactId>rice-middleware</artifactId>

--- a/rice-middleware/sampleapp/pom.xml
+++ b/rice-middleware/sampleapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-middleware</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-sampleapp</artifactId>
   <packaging>war</packaging>

--- a/rice-middleware/serviceregistry/pom.xml
+++ b/rice-middleware/serviceregistry/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-middleware</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-serviceregistry</artifactId>
 	<packaging>war</packaging>

--- a/rice-middleware/standalone/pom.xml
+++ b/rice-middleware/standalone/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-middleware</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-standalone</artifactId>
   <packaging>war</packaging>

--- a/rice-middleware/web/pom.xml
+++ b/rice-middleware/web/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.kuali.rice</groupId>
     <artifactId>rice-middleware</artifactId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-web</artifactId>
   <packaging>war</packaging>

--- a/rice-tools-test/pom.xml
+++ b/rice-tools-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>rice</artifactId>
     <groupId>org.kuali.rice</groupId>
-    <version>2.6.0-M1-SNAPSHOT</version>
+    <version>2.6.x-SNAPSHOT</version>
   </parent>
   <artifactId>rice-tools-test</artifactId>
   <properties>


### PR DESCRIPTION
Updated all of the pom.xml files to the version "2.6.x-SNAPSHOT" since we will be using "mvn versions:set" to set version numbers according to Bamboo build number for the continuous delivery pipeline.
