### PR TITLE
RICE-8: Added a whitelist for the form/lookup return location

### DIFF
--- a/rice-framework/krad-app-framework/src/main/java/org/kuali/rice/krad/util/KRADConstants.java
+++ b/rice-framework/krad-app-framework/src/main/java/org/kuali/rice/krad/util/KRADConstants.java
@@ -194,6 +194,8 @@ public final class KRADConstants {
     public static final String LOGOFF_REDIRECT_URL_PARAMETER = "LOGOFF_REDIRECT_URL";
     public static final String LOGOFF_REDIRECT_URL_PROPERTY = "rice.portal.logout.redirectUrl";
     public static final String PORTAL_ALLOWED_REGEX = "rice.portal.allowed.regex";
+    public static final String BACK_LOCATION_ALLOWED_REGEX = "rice.backLocation.allowed.regex";
+    public static final String BACK_LOCATION_DEFAULT_URL = "rice.backLocation.default.url";
     //    public static final String BLANKET_APPROVE_METHOD = "blanketApprove";
     public static final String BUSINESS_OBJECT_CLASS_ATTRIBUTE = "businessObjectClassName";
     public static final String DATA_OBJECT_CLASS_ATTRIBUTE = "dataObjectClassName";

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/preferences/web/PreferencesForm.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/preferences/web/PreferencesForm.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kuali.rice.core.api.exception.RiceRuntimeException;
 import org.kuali.rice.kew.api.preferences.Preferences;
 import org.kuali.rice.kew.preferences.web.PreferencesConstants;
+import org.kuali.rice.kns.util.WebUtils;
 import org.kuali.rice.kns.web.struts.form.KualiForm;
 import org.kuali.rice.krad.exception.ValidationException;
 import org.kuali.rice.krad.util.GlobalVariables;
@@ -90,7 +91,7 @@ public class PreferencesForm extends KualiForm {
     }
     
 	public String getBackLocation() {
-		return this.backLocation;
+		return WebUtils.sanitizeBackLocation(this.backLocation);
 	}
 	public void setBackLocation(String backLocation) {
 		this.backLocation = backLocation;

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/stats/web/StatsForm.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/stats/web/StatsForm.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.kuali.rice.kew.stats.Stats;
 import org.kuali.rice.kew.api.KewApiConstants;
+import org.kuali.rice.kns.util.WebUtils;
 import org.kuali.rice.kns.web.struts.form.KualiForm;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.KRADConstants;
@@ -276,7 +277,7 @@ public class StatsForm extends KualiForm {
     }
 
 	public String getBackLocation() {
-		return this.backLocation;
+		return WebUtils.sanitizeBackLocation(this.backLocation);
 	}
 
 	public void setBackLocation(String backLocation) {

--- a/rice-middleware/impl/src/main/resources/META-INF/common-config-defaults.xml
+++ b/rice-middleware/impl/src/main/resources/META-INF/common-config-defaults.xml
@@ -134,6 +134,10 @@
 	  <param name="rice.portal.links.showRiceServerConfig" override="false">false</param>
 	  <param name="rice.portal.logout.redirectUrl" override="false">${application.url}/portal.do</param>
     <param name="rice.portal.allowed.regex" override="false">^${application.url}(/.*|)</param>
+    
+    <!-- Back Location parameters -->
+    <param name="rice.backLocation.allowed.regex" override="false">^(${application.url}|${rice.url}|${appserver.url})(/.*|)</param>
+    <param name="rice.backLocation.default.url" override="false">${application.url}</param>
 
     <!-- App specific parameters -->
     <param name="externalizable.help.url" override="false">${application.url}/kr/static/help/</param>

--- a/rice-middleware/kns/src/main/java/org/kuali/rice/kns/lookup/AbstractLookupableHelperServiceImpl.java
+++ b/rice-middleware/kns/src/main/java/org/kuali/rice/kns/lookup/AbstractLookupableHelperServiceImpl.java
@@ -52,6 +52,7 @@ import org.kuali.rice.kns.service.KNSServiceLocator;
 import org.kuali.rice.kns.service.MaintenanceDocumentDictionaryService;
 import org.kuali.rice.kns.util.FieldUtils;
 import org.kuali.rice.kns.util.KNSConstants;
+import org.kuali.rice.kns.util.WebUtils;
 import org.kuali.rice.kns.web.comparator.CellComparatorHelper;
 import org.kuali.rice.kns.web.struts.form.LookupForm;
 import org.kuali.rice.kns.web.struts.form.MultipleValueLookupForm;
@@ -737,7 +738,7 @@ public abstract class AbstractLookupableHelperServiceImpl implements LookupableH
      * @return Returns the backLocation.
      */
     public String getBackLocation() {
-        return backLocation;
+        return WebUtils.sanitizeBackLocation(backLocation);
     }
 
     /**

--- a/rice-middleware/kns/src/main/java/org/kuali/rice/kns/util/WebUtils.java
+++ b/rice-middleware/kns/src/main/java/org/kuali/rice/kns/util/WebUtils.java
@@ -52,6 +52,7 @@ import org.apache.struts.upload.FormFile;
 import org.apache.struts.upload.MultipartRequestHandler;
 import org.apache.struts.upload.MultipartRequestWrapper;
 import org.kuali.rice.core.api.CoreApiServiceLocator;
+import org.kuali.rice.core.api.config.property.ConfigContext;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
 import org.kuali.rice.core.api.util.RiceKeyConstants;
 import org.kuali.rice.kew.api.action.ActionRequest;
@@ -956,6 +957,15 @@ public class WebUtils {
             return path;
         }
         return base + path;
+    }
+    
+    public static String sanitizeBackLocation(String backLocation) {
+        Pattern pattern = Pattern.compile(ConfigContext.getCurrentContextConfig().getProperty(KRADConstants.BACK_LOCATION_ALLOWED_REGEX));
+        if(pattern.matcher(backLocation).matches()) {
+            return backLocation;
+        } else {
+            return ConfigContext.getCurrentContextConfig().getProperty(KRADConstants.BACK_LOCATION_DEFAULT_URL);
+        }
     }
 
 }

--- a/rice-middleware/kns/src/main/java/org/kuali/rice/kns/web/struts/form/KualiForm.java
+++ b/rice-middleware/kns/src/main/java/org/kuali/rice/kns/web/struts/form/KualiForm.java
@@ -484,7 +484,7 @@ public class KualiForm extends PojoFormBase {
 	 * @return the backLocation
 	 */
 	public String getBackLocation() {
-		return this.backLocation;
+		return WebUtils.sanitizeBackLocation(this.backLocation);
 	}
 
 	/**

--- a/rice-middleware/kns/src/test/groovy/org/kuali/rice/kns/util/WebUtilsTest.groovy
+++ b/rice-middleware/kns/src/test/groovy/org/kuali/rice/kns/util/WebUtilsTest.groovy
@@ -44,6 +44,10 @@ import org.kuali.rice.kew.api.KewApiConstants
  */
 @Deprecated
 class WebUtilsTest {
+	
+	private static final String DEFAULT_URL = "default";
+	private static final String TEST_URL = "http://test/url";
+	
     def strutsControllerConfig = { "250M" } as ControllerConfig;
     String maxUploadSize;
     String maxAttachmentSize;
@@ -169,4 +173,34 @@ class WebUtilsTest {
         WebUtils.reopenInactiveRecords(sections, tabstates, "containerField")
         assertEquals([containerFieldelementcontainedvalueonecontainedvaluetwocontainedvaluethree:"OPEN"], tabstates)
     }
+	
+	@Test
+	void testSanitizeBackLocation() {
+		def config = new SimpleConfig()
+		config.putProperty(KRADConstants.BACK_LOCATION_ALLOWED_REGEX, "^http://test.*");
+		config.putProperty(KRADConstants.BACK_LOCATION_DEFAULT_URL, DEFAULT_URL);
+		ConfigContext.init(config);
+		
+		assertEquals(TEST_URL, WebUtils.sanitizeBackLocation(TEST_URL));
+	}
+	
+	@Test
+	void testSanitizeBackLocationWithDisallowedUrl() {
+		def config = new SimpleConfig()
+		config.putProperty(KRADConstants.BACK_LOCATION_ALLOWED_REGEX, "^http://test.*");
+		config.putProperty(KRADConstants.BACK_LOCATION_DEFAULT_URL, DEFAULT_URL);
+		ConfigContext.init(config);
+		
+		assertEquals(DEFAULT_URL, WebUtils.sanitizeBackLocation("http://disallowed"));
+	}
+	
+	@Test
+	void testSanitizeBackLocationWithJavaScriptProtocol() {
+		def config = new SimpleConfig()
+		config.putProperty(KRADConstants.BACK_LOCATION_ALLOWED_REGEX, "^http://test.*");
+		config.putProperty(KRADConstants.BACK_LOCATION_DEFAULT_URL, DEFAULT_URL);
+		ConfigContext.init(config);
+		
+		assertEquals(DEFAULT_URL, WebUtils.sanitizeBackLocation("javascript:alert('test')"));
+	}
 }

--- a/rice-middleware/kns/src/test/groovy/org/kuali/rice/kns/web/struts/form/LookupFormTest.groovy
+++ b/rice-middleware/kns/src/test/groovy/org/kuali/rice/kns/web/struts/form/LookupFormTest.groovy
@@ -57,6 +57,7 @@ class LookupFormTest {
     void setupFakeEnv() {
         def config = new SimpleConfig()
         config.putProperty(CoreConstants.Config.APPLICATION_ID, "APPID");
+		config.putProperty(KRADConstants.BACK_LOCATION_ALLOWED_REGEX, ".*");
         ConfigContext.init(config);
 
         GlobalResourceLoader.stop();
@@ -100,6 +101,7 @@ class LookupFormTest {
         req.addParameter(KRADConstants.BUSINESS_OBJECT_CLASS_ATTRIBUTE, TestBO.class.getName())
         req.addParameter(LookupForm.HEADER_BAR_ENABLED_PARAM, "false")
         req.addParameter(LookupForm.SEARCH_CRITERIA_ENABLED_PARAM, "false")
+		req.addParameter(KRADConstants.RETURN_LOCATION_PARAMETER, "http://test");
 
         form.populate(req)
 


### PR DESCRIPTION
- Added a white list which the back location (aka returnLocation query
  parameter) must return the user to an expected location
- Primarily used in "return value" links in lookups and the cancel
  button which appears on many screens
- Defaults to the application.url, rice.url or anything matching the
  appserver.url in the application's configuration
- If the white list is not matched it will return the user to a configurable default URL (defaults to application.url)
