### PR TITLE
Support differnt kns database platform

### DIFF
--- a/rice-framework/krad-web-framework/src/main/resources/org/kuali/rice/krad/config/KRADSpringBeans-data.xml
+++ b/rice-framework/krad-web-framework/src/main/resources/org/kuali/rice/krad/config/KRADSpringBeans-data.xml
@@ -78,6 +78,12 @@
 			value="false" />
 	</bean>
 
+	<bean id="kradDbPlatform" class="org.kuali.rice.core.framework.persistence.platform.ConfigurableDatabasePlatform">
+		<property name="configProperty" value="krad.datasource.platform"/>
+		<property name="defaultPlatform" ref="dbPlatform"/>
+	</bean>
+
+
 	<bean
 		id="platformAwareDaoJdbc"
 		abstract="true"
@@ -87,7 +93,7 @@
 			ref="kradApplicationDataSource" />
 		<property
 			name="dbPlatform"
-			ref="dbPlatform" />
+			ref="kradDbPlatform" />
 	</bean>
 
 	<import resource="KRADSpringBeans-jpa.xml" />

--- a/rice-framework/krad-web-framework/src/main/resources/org/kuali/rice/krad/config/KRADSpringBeans.xml
+++ b/rice-framework/krad-web-framework/src/main/resources/org/kuali/rice/krad/config/KRADSpringBeans.xml
@@ -674,7 +674,7 @@
   <bean id="lookupCriteriaGenerator" class="org.kuali.rice.krad.service.impl.LookupCriteriaGeneratorImpl"
         p:dateTimeService-ref="dateTimeService"
         p:dataDictionaryService-ref="dataDictionaryService"
-        p:dbPlatform-ref="dbPlatform"
+        p:dbPlatform-ref="kradDbPlatform"
         p:dataObjectService-ref="dataObjectService"/>
 
   <!-- Legacy Data Adapter Beans -->

--- a/rice-middleware/core/framework/src/main/java/org/kuali/rice/core/framework/persistence/platform/ConfigurableDatabasePlatform.java
+++ b/rice-middleware/core/framework/src/main/java/org/kuali/rice/core/framework/persistence/platform/ConfigurableDatabasePlatform.java
@@ -1,0 +1,52 @@
+package org.kuali.rice.core.framework.persistence.platform;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.core.api.config.property.ConfigContext;
+import org.kuali.rice.core.api.util.ClassLoaderUtils;
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Factory bean that allows for loading a {@link DatabasePlatform} from a classname specified by a specified
+ * configProperty. If the configProperty has no value, then the provided defaultPlatform will be returned from this
+ * factory bean instead.
+ *
+ * @author Eric Westfall
+ */
+public class ConfigurableDatabasePlatform implements FactoryBean<DatabasePlatform> {
+
+    private String configProperty;
+    private DatabasePlatform defaultPlatform;
+
+    @Override
+    public DatabasePlatform getObject() throws Exception {
+        if (!StringUtils.isBlank(configProperty)) {
+            String platformClassName = ConfigContext.getCurrentContextConfig().getProperty(configProperty);
+            if (!StringUtils.isBlank(platformClassName)) {
+                return (DatabasePlatform)ClassLoaderUtils.getClass(platformClassName).newInstance();
+            }
+        }
+        if (defaultPlatform == null) {
+            throw new IllegalArgumentException("No value for config property '" + configProperty + "' and no default platform specified.");
+        }
+        return defaultPlatform;
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return DatabasePlatform.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    public void setConfigProperty(String configProperty) {
+        this.configProperty = configProperty;
+    }
+
+    public void setDefaultPlatform(DatabasePlatform defaultPlatform) {
+        this.defaultPlatform = defaultPlatform;
+    }
+
+}

--- a/rice-middleware/impl/src/main/resources/META-INF/common-config-defaults.xml
+++ b/rice-middleware/impl/src/main/resources/META-INF/common-config-defaults.xml
@@ -48,6 +48,7 @@
     <param name="datasource.pool.maxWait" override="false">30000</param>
 
     <param name="datasource.ojb.platform" override="false">Oracle9i</param>
+    <param name="krad.datasource.ojb.platform" override="false">${datasource.ojb.platform}</param>
 
     <param name="datasource.driver.name.Oracle" override="false">oracle.jdbc.OracleDriver</param>
     <param name="datasource.platform.Oracle" override="false">org.kuali.rice.core.framework.persistence.platform.OracleDatabasePlatform</param>
@@ -59,12 +60,16 @@
     <param name="datasource.platform.Oracle9i" override="false">org.kuali.rice.core.framework.persistence.platform.OracleDatabasePlatform</param>
     <param name="datasource.ojb.sequenceManager.Oracle9i" override="false"></param>
     <param name="datasource.ojb.sequenceManager.className.Oracle9i" override="false"></param>
+    <param name="krad.datasource.ojb.sequenceManager.Oracle9i" override="false"></param>
+    <param name="krad.datasource.ojb.sequenceManager.className.Oracle9i" override="false"></param>
     <param name="datasource.pool.validationQuery.Oracle9i" override="false">select 1 from dual</param>
 
     <param name="datasource.driver.name.MySQL" override="false">com.mysql.jdbc.Driver</param>
     <param name="datasource.platform.MySQL" override="false">org.kuali.rice.core.framework.persistence.platform.MySQLDatabasePlatform</param>
     <param name="datasource.ojb.sequenceManager.MySQL" override="false">org.apache.ojb.broker.platforms.KualiMySQLSequenceManagerImpl</param>
     <param name="datasource.ojb.sequenceManager.className.MySQL" override="false">org.apache.ojb.broker.platforms.KualiMySQLSequenceManagerImpl</param>
+    <param name="krad.datasource.ojb.sequenceManager.MySQL" override="false">org.apache.ojb.broker.platforms.KualiMySQLSequenceManagerImpl</param>
+    <param name="krad.datasource.ojb.sequenceManager.className.MySQL" override="false">org.apache.ojb.broker.platforms.KualiMySQLSequenceManagerImpl</param>
     <param name="datasource.pool.validationQuery.MySQL" override="false">select 1</param>
 
     <param name="datasource.driver.name.Derby" override="false">org.apache.derby.jdbc.EmbeddedDriver</param>
@@ -77,6 +82,8 @@
     <param name="datasource.platform" override="false">${datasource.platform.${datasource.ojb.platform}}</param>
     <param name="datasource.ojb.sequenceManager" override="false">${datasource.ojb.sequenceManager.${datasource.ojb.platform}}</param>
     <param name="datasource.ojb.sequenceManager.className" override="false">${datasource.ojb.sequenceManager.className.${datasource.ojb.platform}}</param>
+    <param name="krad.datasource.ojb.sequenceManager" override="false">${krad.datasource.ojb.sequenceManager.${krad.datasource.ojb.platform}}</param>
+    <param name="krad.datasource.ojb.sequenceManager.className" override="false">${krad.datasource.ojb.sequenceManager.className.${krad.datasource.ojb.platform}}</param>
     <param name="datasource.pool.validationQuery" override="false">${datasource.pool.validationQuery.${datasource.ojb.platform}}</param>
 
     <!-- datasource.btm.journal can be "null", "disk", or a class name -->

--- a/rice-middleware/impl/src/main/resources/org/kuali/rice/kns/config/KNSSpringBeans.xml
+++ b/rice-middleware/impl/src/main/resources/org/kuali/rice/kns/config/KNSSpringBeans.xml
@@ -369,7 +369,7 @@
         p:dataDictionaryService-ref="dataDictionaryService"
         p:dataObjectMetaDataService-ref="dataObjectMetaDataService"
         p:kualiConfigurationService-ref="kualiConfigurationService"
-        p:databasePlatform-ref="dbPlatform"
+        p:databasePlatform-ref="kradDbPlatform"
         p:documentDao-ref="documentDao"
         p:dateTimeService-ref="dateTimeService"
         p:viewDictionaryService-ref="viewDictionaryService"/>
@@ -407,6 +407,7 @@
       </list>
     </property>
     <property name="metadataLocation" value="classpath:org/kuali/rice/kns/config/OJB-repository-kns.xml"/>
+    <property name="platformConfigProperty" value="krad.datasource.ojb.platform" />
   </bean>
 
   <bean id="ojbCollectionHelper" class="org.kuali.rice.krad.service.util.OjbCollectionHelper"/>
@@ -414,13 +415,13 @@
   <bean id="platformAwareDao" abstract="true"
         class="org.kuali.rice.core.framework.persistence.ojb.dao.PlatformAwareDaoBaseOjb">
     <property name="jcdAlias" value="kradApplicationDataSource"/>
-    <property name="dbPlatform" ref="dbPlatform"/>
+    <property name="dbPlatform" ref="kradDbPlatform"/>
   </bean>
 
   <bean id="platformAwareDaoJdbc" abstract="true"
         class="org.kuali.rice.core.framework.persistence.jdbc.dao.PlatformAwareDaoBaseJdbc">
     <property name="dataSource" ref="kradApplicationDataSource"/>
-    <property name="dbPlatform" ref="dbPlatform"/>
+    <property name="dbPlatform" ref="kradDbPlatform"/>
   </bean>
 
   <bean id="persistenceStructureServiceOjb"
@@ -432,7 +433,7 @@
 
   <bean id="persistenceDaoOjb" parent="platformAwareDao" class="org.kuali.rice.krad.dao.impl.PersistenceDaoOjb">
     <property name="jcdAlias" value="kradApplicationDataSource"/>
-    <property name="dbPlatform" ref="dbPlatform"/>
+    <property name="dbPlatform" ref="kradDbPlatform"/>
   </bean>
 
   <bean id="documentDaoOjb" parent="platformAwareDao" class="org.kuali.rice.krad.dao.impl.DocumentDaoOjb">

--- a/rice-middleware/impl/src/main/resources/org/kuali/rice/kns/config/OJB-repository-kns.xml
+++ b/rice-middleware/impl/src/main/resources/org/kuali/rice/kns/config/OJB-repository-kns.xml
@@ -22,7 +22,7 @@
                               useAutoCommit="0" ignoreAutoCommitExceptions="false">
     <object-cache class="org.apache.ojb.broker.cache.ObjectCachePerBrokerImpl"/>
     <sequence-manager className="org.kuali.rice.core.framework.persistence.ojb.ConfigurableSequenceManager">
-      <attribute attribute-name="property.prefix" attribute-value="datasource.ojb.sequenceManager"/>
+      <attribute attribute-name="property.prefix" attribute-value="krad.datasource.ojb.sequenceManager"/>
     </sequence-manager>
   </jdbc-connection-descriptor>
 

--- a/rice-middleware/kns/src/main/java/org/kuali/rice/core/framework/persistence/ojb/BaseOjbConfigurer.java
+++ b/rice-middleware/kns/src/main/java/org/kuali/rice/core/framework/persistence/ojb/BaseOjbConfigurer.java
@@ -74,6 +74,12 @@ public class BaseOjbConfigurer extends BaseLifecycle implements InitializingBean
     protected List<String> additionalMetadataLocations;
 
     /**
+     * Defines the config property to use to determine the database platform for this OJB Configurer, configurer will
+     * check this first then fall back to the default of {@link Config#OJB_PLATFORM}
+     */
+    private String platformConfigProperty;
+
+    /**
      * No-arg constructor
      */
     public BaseOjbConfigurer() {
@@ -165,9 +171,9 @@ public class BaseOjbConfigurer extends BaseLifecycle implements InitializingBean
             Element descriptor = (Element)connectionDescriptors.item(index);
             String currentPlatform = descriptor.getAttribute("platform");
             if (StringUtils.isBlank(currentPlatform)) {
-                String ojbPlatform = ConfigContext.getCurrentContextConfig().getProperty(Config.OJB_PLATFORM);
+                String ojbPlatform = ConfigContext.getCurrentContextConfig().getProperty(identifyValidPlatformConfigProperty());
                 if (StringUtils.isEmpty(ojbPlatform)) {
-                    throw new ConfigurationException("Could not configure OJB, the '" + Config.OJB_PLATFORM + "' configuration property was not set.");
+                    throw new ConfigurationException("Could not configure OJB, the '" + identifyValidPlatformConfigProperty() + "' configuration property was not set.");
                 }
                 LOG.info("Setting OJB connection descriptor database platform to '" + ojbPlatform + "'");
                 descriptor.setAttribute("platform", ojbPlatform);
@@ -290,5 +296,24 @@ public class BaseOjbConfigurer extends BaseLifecycle implements InitializingBean
      */
     public void setAdditionalMetadataLocations(List<String> additionalMetadataLocations) {
         this.additionalMetadataLocations = additionalMetadataLocations;
+    }
+
+    public String getPlatformConfigProperty() {
+        return platformConfigProperty;
+    }
+
+    public void setPlatformConfigProperty(String platformConfigProperty) {
+        this.platformConfigProperty = platformConfigProperty;
+    }
+
+    private String identifyValidPlatformConfigProperty() {
+        String validPlatformConfigProperty = Config.OJB_PLATFORM;
+        if (!StringUtils.isBlank(getPlatformConfigProperty())) {
+            String ojbPlatform = ConfigContext.getCurrentContextConfig().getProperty(getPlatformConfigProperty());
+            if (!StringUtils.isBlank(ojbPlatform)) {
+                validPlatformConfigProperty = getPlatformConfigProperty();
+            }
+        }
+        return validPlatformConfigProperty;
     }
 }

--- a/rice-middleware/kns/src/main/java/org/kuali/rice/core/framework/persistence/ojb/ConfigurableSequenceManager.java
+++ b/rice-middleware/kns/src/main/java/org/kuali/rice/core/framework/persistence/ojb/ConfigurableSequenceManager.java
@@ -116,15 +116,17 @@ public class ConfigurableSequenceManager implements SequenceManager {
 		return this.broker;
 	}
 
-	public String getPropertyPrefix() {
+	private String getPropertyPrefix() {
+		String propertyPrefix = DEFAULT_PROPERTY_PREFIX;
+		// check the sequence descriptor
 		SequenceDescriptor sd = getBroker().serviceConnectionManager().getConnectionDescriptor().getSequenceDescriptor();
-		String propertyPrefix = null;
 		if (sd != null) {
-			propertyPrefix = sd.getConfigurationProperties().getProperty(PROPERTY_PREFIX_ATTRIBUTE);
-		}
-		if (StringUtils.isBlank(propertyPrefix)) {
-			propertyPrefix = DEFAULT_PROPERTY_PREFIX;
+			String configuredPropertyPrefix = sd.getConfigurationProperties().getProperty(PROPERTY_PREFIX_ATTRIBUTE);
+			if (!StringUtils.isBlank(ConfigContext.getCurrentContextConfig().getProperty(getSequenceManagerClassNameProperty(configuredPropertyPrefix)))) {
+				propertyPrefix = configuredPropertyPrefix;
+			}
 		}
 		return propertyPrefix;
 	}
+
 }


### PR DESCRIPTION
This pull request makes it possible to configure a database "platform" for a KRAD/KNS client application which differs from the standalone Rice server it's integrated with.

In otherwords, a Rice client application could be using MySQL while the standalone server remains on Oracle. This is a specific requirement at Indiana University where we plan to migrate our KFS to MySQL but remain on Oracle for Kuali Rice (until we retire it).

In order to take advantage of this, one simply needs to configure the `krad.datasource.platform` and `krad.datasource.ojb.platform` config properties. The first of these should be the fully qualified classname of the `org.kuali.rice.core.framework.persistence.platform.DatabasePlatform` implementation to use. The second of these will be the OJB platform name, one of 'MySQL', 'Oracle', or 'Oracle9i'

This enhancement should be fully backward compatible, not requiring any configuration changes for existing applications when this new version is pulled in.