### PR TITLE
RICE-60 Role service api issues - delegation attributes not saved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
     <!-- Plugin versions: -->
 
     <plugin.build-helper.version>1.8</plugin.build-helper.version>
+    <plugin.github-site.version>0.12</plugin.github-site.version>
     <plugin.gmavenplus.version>1.5</plugin.gmavenplus.version>
     <plugin.http.version>1.0.5</plugin.http.version>
     <plugin.jetty.version>9.3.6.v20151106</plugin.jetty.version>
@@ -294,9 +295,8 @@
   <distributionManagement>
     <downloadUrl>${kuali.site.download.url}</downloadUrl>
     <site>
-      <id>${kuali.site.server.id}</id>
-      <name>Kuali Maven Site</name>
-      <url>${kuali.site.publish.url}</url>
+      <id>github-pages</id>
+      <url>scm:git:https://github.com/KualiCo/rice.git</url>
     </site>
     <repository>
       <id>${kuali.repo.release.id}</id>
@@ -535,6 +535,30 @@
       </properties>
       <build>
         <plugins>
+          <plugin>
+            <groupId>com.github.github</groupId>
+            <artifactId>site-maven-plugin</artifactId>
+            <version>${plugin.github-site.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>site</goal>
+                </goals>
+                <phase>site-deploy</phase>
+                <configuration>
+                  <server>github-pages</server>
+                  <message>Updating documentation</message>
+                  <merge>true</merge>
+                  <host>https://github.com</host>
+                  <includes>
+                    <include>apidocs/**/*</include>
+                    <include>reference/**/*</include>
+                  </includes>
+                  <path>${project.version}</path>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>com.mycila.maven-license-plugin</groupId>
             <artifactId>maven-license-plugin</artifactId>

--- a/rice-middleware/it/kim/src/test/java/org/kuali/rice/kim/test/service/RoleServiceTest.java
+++ b/rice-middleware/it/kim/src/test/java/org/kuali/rice/kim/test/service/RoleServiceTest.java
@@ -17,11 +17,16 @@ package org.kuali.rice.kim.test.service;
 
 import com.google.common.collect.Maps;
 import org.junit.Test;
+import org.kuali.rice.core.api.delegation.DelegationType;
 import org.kuali.rice.core.api.membership.MemberType;
+import org.kuali.rice.kim.api.common.delegate.DelegateMember;
+import org.kuali.rice.kim.api.common.delegate.DelegateType;
 import org.kuali.rice.kim.api.role.Role;
 import org.kuali.rice.kim.api.role.RoleMember;
 import org.kuali.rice.kim.api.role.RoleService;
 import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.rice.kim.api.type.KimType;
+import org.kuali.rice.kim.api.type.KimTypeInfoService;
 import org.kuali.rice.kim.test.KIMTestCase;
 import org.kuali.rice.test.BaselineTestCase;
 
@@ -41,31 +46,33 @@ import static org.junit.Assert.*;
  * @author Kuali Rice Team (rice.collab@kuali.org)
  *
  */
-@BaselineTestCase.BaselineMode(BaselineTestCase.Mode.NONE)
+@BaselineTestCase.BaselineMode(BaselineTestCase.Mode.CLEAR_DB)
 public class RoleServiceTest extends KIMTestCase {
 
 	private RoleService roleService;
+	private KimTypeInfoService kimTypeInfoService;
 
 	public void setUp() throws Exception {
 		super.setUp();
-		setRoleService(KimApiServiceLocator.getRoleService());
+		this.roleService = KimApiServiceLocator.getRoleService();
+		this.kimTypeInfoService = KimApiServiceLocator.getKimTypeInfoService();
 	}
 	
 	@Test
 	public void testPrincipaHasRoleOfDirectAssignment() {
 		List <String>roleIds = new ArrayList<String>();
 		roleIds.add("r1");
-		assertTrue( "p1 has direct role r1", getRoleService().principalHasRole("p1", roleIds, Collections.<String, String>emptyMap() ));
-		//assertFalse( "p4 has no direct/higher level role r1", getRoleService().principalHasRole("p4", roleIds, null ));	
+		assertTrue( "p1 has direct role r1", roleService.principalHasRole("p1", roleIds, Collections.<String, String>emptyMap() ));
+		//assertFalse( "p4 has no direct/higher level role r1", roleService.principalHasRole("p4", roleIds, null ));	
 		Map<String, String> qualification = new HashMap<String, String>();
 		qualification.put("Attribute 2", "CHEM");
-		assertTrue( "p1 has direct role r1 with rp2 attr data", getRoleService().principalHasRole("p1", roleIds,
+		assertTrue( "p1 has direct role r1 with rp2 attr data", roleService.principalHasRole("p1", roleIds,
                 qualification));
 		qualification.clear();
 		//requested qualification rolls up to a higher element in some hierarchy 
 		// method not implemented yet, not quite clear how this works
 		qualification.put("Attribute 3", "PHYS");
-		assertTrue( "p1 has direct role r1 with rp2 attr data", getRoleService().principalHasRole("p1", roleIds, Maps.newHashMap(
+		assertTrue( "p1 has direct role r1 with rp2 attr data", roleService.principalHasRole("p1", roleIds, Maps.newHashMap(
                 qualification)));
 	}
 
@@ -74,7 +81,7 @@ public class RoleServiceTest extends KIMTestCase {
 		// "p3" is in "r2" and "r2 contains "r1"
 		List <String>roleIds = new ArrayList<String>();
 		roleIds.add("r2");
-		assertTrue( "p1 has assigned in higher level role r1", getRoleService().principalHasRole("p1", roleIds, Collections.<String, String>emptyMap() ));
+		assertTrue( "p1 has assigned in higher level role r1", roleService.principalHasRole("p1", roleIds, Collections.<String, String>emptyMap() ));
 	}
 	
 	@Test
@@ -82,7 +89,7 @@ public class RoleServiceTest extends KIMTestCase {
 		// "p2" is in "g1" and "g1" assigned to "r2"
 		List <String>roleIds = new ArrayList<String>();
 		roleIds.add("r2");
-		assertTrue( "p2 is assigned to g1 and g1 assigned to r2", getRoleService().principalHasRole("p2", roleIds, Collections.<String, String>emptyMap() ));
+		assertTrue( "p2 is assigned to g1 and g1 assigned to r2", roleService.principalHasRole("p2", roleIds, Collections.<String, String>emptyMap() ));
 	}
 
 	@Test
@@ -91,7 +98,7 @@ public class RoleServiceTest extends KIMTestCase {
 		List <String>roleIds = new ArrayList<String>();
 		Collection <String>rolePrincipalIds;
 		roleIds.add("r101");
-		rolePrincipalIds = getRoleService().getRoleMemberPrincipalIds("ADDL_ROLES_TESTS", "Role A",  Collections
+		rolePrincipalIds = roleService.getRoleMemberPrincipalIds("ADDL_ROLES_TESTS", "Role A",  Collections
                 .<String, String>emptyMap());
 		assertNotNull(rolePrincipalIds);
 		assertEquals("RoleTwo should have 6 principal ids", 5, rolePrincipalIds.size());
@@ -102,27 +109,94 @@ public class RoleServiceTest extends KIMTestCase {
 	 */
 	@Test
 	public void testSwitchFromPrimaryToSecondaryDelegation() {
+
+		// get the kim type for our role, one that supports two attributes
+		KimType typeWithAttributes = kimTypeInfoService.findKimTypeByNameAndNamespace("TEST", "type-with-attributes");
+		assertNotNull(typeWithAttributes);
+
 		// first let's create a new Role with a delegation
 		String roleId = UUID.randomUUID().toString();
-		Role.Builder roleBuilder = Role.Builder.create(roleId, "testSwitchFromPrimaryToSecondaryDelegation", "TEST", "test role", "1");
-		Role role = getRoleService().createRole(roleBuilder.build());
+		// note that we are appending role id to the name here to avoid conflicts when the "RemoteRoleServiceTest" runs, since the test harness is not clearing out KIM data for us and this will allow
+		// us to be lazy and not have to clean up after ourself after this test runs
+		Role.Builder roleBuilder = Role.Builder.create(roleId, "testSwitchFromPrimaryToSecondaryDelegation" + roleId, "TEST", "test role", typeWithAttributes.getId());
+		Role role = roleService.createRole(roleBuilder.build());
 
 		// now assign a member
 		String roleMemberId = UUID.randomUUID().toString();
 		RoleMember.Builder roleMemberBuilder = RoleMember.Builder.create(roleId, roleMemberId, "p10", MemberType.PRINCIPAL, null, null, null, null, null);
-		RoleMember roleMember = getRoleService().createRoleMember(roleMemberBuilder.build());
+		RoleMember roleMember = roleService.createRoleMember(roleMemberBuilder.build());
 
 		// now create a delegation
-		getRoleService().createDelegateType()
+		DelegateType.Builder delegateTypeBuilder = DelegateType.Builder.create(roleId, DelegationType.PRIMARY, new ArrayList<>());
+		delegateTypeBuilder.setKimTypeId(typeWithAttributes.getId());
+		DelegateType primaryDelegateType = roleService.createDelegateType(delegateTypeBuilder.build());
+		
+		// and now let's add a delegation member
+		DelegateMember.Builder delegateMemberBuilder = DelegateMember.Builder.create();
+		delegateMemberBuilder.setDelegationId(primaryDelegateType.getDelegationId());
+		delegateMemberBuilder.setRoleMemberId(roleMember.getMemberId());
+		delegateMemberBuilder.setType(MemberType.PRINCIPAL);
+		delegateMemberBuilder.setMemberId("p9");
+		Map<String, String> attributes = new HashMap<String, String>();
+		attributes.put("attr1", "value1");
+		attributes.put("attr2", "value2");
+		delegateMemberBuilder.setAttributes(attributes);
+		DelegateMember delegateMember = roleService.createDelegateMember(delegateMemberBuilder.build());
+
+		assertNotNull(delegateMember.getDelegationMemberId());
+		// just a sanity check, we should have one primary delegation member
+		assertEquals(1, roleService.getDelegationMembersByDelegationId(primaryDelegateType.getDelegationId()).size());
+
+		// now what we are going to do is try to run some code that will switch the delegation from primary to secondary
+
+		// first let's fetch our member, and make sure it has the correct attributes
+		DelegateMember originalMember = roleService.getDelegationMemberById(delegateMember.getDelegationMemberId());
+		assertNotNull(originalMember);
+		Map<String, String> originalMemberAttributes = originalMember.getAttributes();
+		assertEquals(2, originalMemberAttributes.keySet().size());
+		assertEquals("value1", originalMemberAttributes.get("attr1"));
+		assertEquals("value2", originalMemberAttributes.get("attr2"));
+		DelegateMember.Builder updatedMember = DelegateMember.Builder.create(originalMember);
+
+		// We are wanting to change the delegation type to secondary, so first we remove old
+		roleService.removeDelegateMembers(Collections.singletonList(originalMember));
+		// add new
+		DelegateType.Builder delegateTypeBuilder2 = DelegateType.Builder.create(roleId, DelegationType.SECONDARY, new ArrayList<>());
+		delegateTypeBuilder2.setKimTypeId("1"); // set it to the default kim type which has an id of 1
+		DelegateType secondaryDelegateType = roleService.createDelegateType(delegateTypeBuilder2.build());
+
+		DelegateMember.Builder newMember = DelegateMember.Builder.create();
+		newMember.setDelegationId(secondaryDelegateType.getDelegationId());
+		newMember.setMemberId(originalMember.getMemberId());
+		newMember.setType(originalMember.getType());
+		newMember.setRoleMemberId(originalMember.getRoleMemberId());
+		newMember.setAttributes(originalMember.getAttributes());
+		newMember.setActiveFromDate(originalMember.getActiveFromDate());
+		newMember.setActiveToDate(originalMember.getActiveToDate());
+		DelegateMember addedMember = roleService.createDelegateMember(newMember.build());
+
+		// now after all of this, let's check our delegation situation, we should have two DelegateTypes now, one
+		// primary and one seconary the primary delegate type should be empty (have no members) while the secondary one
+		// should have our new delegation member nestled snuggly inside
+
+		DelegateType finalPrimaryDelegateType = roleService.getDelegateTypeByRoleIdAndDelegateTypeCode(roleId, DelegationType.PRIMARY);
+		DelegateType finalSecondaryDelegateType = roleService.getDelegateTypeByRoleIdAndDelegateTypeCode(roleId, DelegationType.SECONDARY);
+
+		assertEquals(1, finalPrimaryDelegateType.getMembers().size());
+		assertEquals(1, finalSecondaryDelegateType.getMembers().size());
+
+		// the primary delegate delegation members should be inactive since we removed it
+		DelegateMember finalPrimaryDelegationMember = finalPrimaryDelegateType.getMembers().get(0);
+		assertFalse(finalPrimaryDelegationMember.isActive());
+
+		DelegateMember finalSecondaryDelegationMember = finalSecondaryDelegateType.getMembers().get(0);
+		assertEquals("p9", finalSecondaryDelegationMember.getMemberId());
+		assertTrue(finalSecondaryDelegationMember.isActive());
+		Map<String, String> finalAttributes = finalSecondaryDelegationMember.getAttributes();
+		assertEquals(2, finalAttributes.keySet().size());
+		assertEquals("value1", finalAttributes.get("attr1"));
+		assertEquals("value2", finalAttributes.get("attr2"));
 
 	}
 	
-	public RoleService getRoleService() {
-		return this.roleService;
-	}
-
-	public void setRoleService(RoleService roleService) {
-		this.roleService = roleService;
-	}
-
 }

--- a/rice-middleware/it/kim/src/test/java/org/kuali/rice/kim/test/service/RoleServiceTest.java
+++ b/rice-middleware/it/kim/src/test/java/org/kuali/rice/kim/test/service/RoleServiceTest.java
@@ -17,6 +17,9 @@ package org.kuali.rice.kim.test.service;
 
 import com.google.common.collect.Maps;
 import org.junit.Test;
+import org.kuali.rice.core.api.membership.MemberType;
+import org.kuali.rice.kim.api.role.Role;
+import org.kuali.rice.kim.api.role.RoleMember;
 import org.kuali.rice.kim.api.role.RoleService;
 import org.kuali.rice.kim.api.services.KimApiServiceLocator;
 import org.kuali.rice.kim.test.KIMTestCase;
@@ -28,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.Assert.*;
 
@@ -91,6 +95,26 @@ public class RoleServiceTest extends KIMTestCase {
                 .<String, String>emptyMap());
 		assertNotNull(rolePrincipalIds);
 		assertEquals("RoleTwo should have 6 principal ids", 5, rolePrincipalIds.size());
+	}
+
+	/**
+	 * This test will verify proper behavior when switching from a primary to a secondary delegation via the API.
+	 */
+	@Test
+	public void testSwitchFromPrimaryToSecondaryDelegation() {
+		// first let's create a new Role with a delegation
+		String roleId = UUID.randomUUID().toString();
+		Role.Builder roleBuilder = Role.Builder.create(roleId, "testSwitchFromPrimaryToSecondaryDelegation", "TEST", "test role", "1");
+		Role role = getRoleService().createRole(roleBuilder.build());
+
+		// now assign a member
+		String roleMemberId = UUID.randomUUID().toString();
+		RoleMember.Builder roleMemberBuilder = RoleMember.Builder.create(roleId, roleMemberId, "p10", MemberType.PRINCIPAL, null, null, null, null, null);
+		RoleMember roleMember = getRoleService().createRoleMember(roleMemberBuilder.build());
+
+		// now create a delegation
+		getRoleService().createDelegateType()
+
 	}
 	
 	public RoleService getRoleService() {

--- a/rice-middleware/it/kim/src/test/resources/org/kuali/rice/kim/test/DefaultSuiteTestData.sql
+++ b/rice-middleware/it/kim/src/test/resources/org/kuali/rice/kim/test/DefaultSuiteTestData.sql
@@ -14,6 +14,25 @@
 -- limitations under the License.
 --
 
+-- Setup a Kim Type with some attributes
+INSERT INTO KRIM_TYP_T(KIM_TYP_ID, OBJ_ID, VER_NBR, NM, SRVC_NM, ACTV_IND, NMSPC_CD)
+	VALUES('type-with-attributes', 'type-with-attributes', 1, 'type-with-attributes', null, 'Y', 'TEST')
+/
+INSERT INTO KRIM_ATTR_DEFN_T (kim_attr_defn_id, obj_id, ver_nbr, nmspc_cd, nm, lbl, actv_ind, cmpnt_nm)
+  VALUES ('attr1', 'attr1', 1, 'TEST', 'attr1', 'attr1', 'Y', NULL)
+/
+INSERT INTO KRIM_ATTR_DEFN_T (kim_attr_defn_id, obj_id, ver_nbr, nmspc_cd, nm, lbl, actv_ind, cmpnt_nm)
+  VALUES ('attr2', 'attr2', 1, 'TEST', 'attr2', 'attr2', 'Y', NULL)
+/
+INSERT INTO KRIM_TYP_ATTR_T(KIM_TYP_ATTR_ID, OBJ_ID, VER_NBR, SORT_CD, KIM_TYP_ID, KIM_ATTR_DEFN_ID, ACTV_IND)
+	VALUES('type-with-attributes-attr1', 'type-with-attributes-attr1', 1, 'a', 'type-with-attributes', 'attr1', 'Y')
+/
+INSERT INTO KRIM_TYP_ATTR_T(KIM_TYP_ATTR_ID, OBJ_ID, VER_NBR, SORT_CD, KIM_TYP_ID, KIM_ATTR_DEFN_ID, ACTV_IND)
+	VALUES('type-with-attributes-attr2', 'type-with-attributes-attr2', 1, 'b', 'type-with-attributes', 'attr2', 'Y')
+/
+
+-- Set Create Role "r1"
+
 INSERT INTO KRIM_ROLE_T (ACTV_IND,KIM_TYP_ID,NMSPC_CD,OBJ_ID,ROLE_ID,ROLE_NM,VER_NBR, DESC_TXT)
   VALUES ('Y','1','AUTH_SVC_TEST1','ea9ed94a-7e6b-102c-97b6-ed716fdaf540','r1','RoleOne',1, 'Role 1 Description')
 /

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/common/delegate/DelegateMemberBo.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/common/delegate/DelegateMemberBo.java
@@ -58,7 +58,7 @@ public class DelegateMemberBo extends AbstractMemberBo implements DelegateMember
 
     @JoinFetch(value= JoinFetchType.OUTER)
     @OneToMany(targetEntity = DelegateMemberAttributeDataBo.class, orphanRemoval = true, cascade = CascadeType.ALL)
-    @JoinColumn(name = "DLGN_MBR_ID", referencedColumnName = "DLGN_MBR_ID", insertable = false, updatable = false)
+    @JoinColumn(name = "DLGN_MBR_ID", referencedColumnName = "DLGN_MBR_ID")
     private List<DelegateMemberAttributeDataBo> attributeDetails = new AutoPopulatingList<DelegateMemberAttributeDataBo>(DelegateMemberAttributeDataBo.class);
 
     @Transient

--- a/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/role/RoleBo.java
+++ b/rice-middleware/kim/kim-impl/src/main/java/org/kuali/rice/kim/impl/role/RoleBo.java
@@ -74,7 +74,7 @@ public class RoleBo extends DataObjectBase implements RoleEbo {
 
     @JoinFetch(value= JoinFetchType.OUTER)
     @OneToMany(targetEntity = RoleMemberBo.class, orphanRemoval = true, cascade = CascadeType.ALL)
-    @JoinColumn(name = "ROLE_ID", referencedColumnName = "ROLE_ID", insertable = false, updatable = false)
+    @JoinColumn(name = "ROLE_ID", referencedColumnName = "ROLE_ID")
     private List<RoleMemberBo> members = new AutoPopulatingList<RoleMemberBo>(RoleMemberBo.class);
 
     @Transient


### PR DESCRIPTION
Fixes the issue of delegation attributes not being saved when using the RoleService API.

This branch also had some work to allow for publishing javadocs to github pages.